### PR TITLE
backticks for mysql column names

### DIFF
--- a/core/DBAdapters/mysql.py
+++ b/core/DBAdapters/mysql.py
@@ -93,7 +93,7 @@ class Adapter:
 
 	@staticmethod
 	def _mysql_column(kwargs):
-		return "{cname} {ctype}{notnull}{unique}{autoincrement}{default}".format(
+		return "`{cname}` {ctype}{notnull}{unique}{autoincrement}{default}".format(
 			cname=kwargs['cname'],
 			ctype=kwargs['ctype'],
 			notnull=" NOT NULL" if kwargs['notnull'] else "",


### PR DESCRIPTION
I was getting mysql syntax error when it was trying to create tables:
`Error in query (1064): Syntax error near 'rank VARCHAR(191) DEFAULT '〈E〉',`