### PR TITLE
fix queue black/white list role check

### DIFF
--- a/bot/queue_channel.py
+++ b/bot/queue_channel.py
@@ -518,9 +518,9 @@ class QueueChannel:
 
 	async def _add_member(self, message, args=None):
 		if self.cfg.blacklist_role and self.cfg.blacklist_role in message.author.roles:
-			raise bot.Exc.PermissionError(self.gt("You are not allowed to add to queues."))
+			raise bot.Exc.PermissionError(self.gt("You are not allowed to add to queues on this channel."))
 		if self.cfg.whitelist_role and self.cfg.whitelist_role not in message.author.roles:
-			raise bot.Exc.PermissionError(self.gt("You are not allowed to add to queues."))
+			raise bot.Exc.PermissionError(self.gt("You are not allowed to add to queues on this channel."))
 
 		if any((message.author in m.players for m in bot.active_matches)):
 			raise bot.Exc.InMatchError(self.gt("You are already in an active match."))
@@ -550,7 +550,7 @@ class QueueChannel:
 		]
 
 		if len(allowed) != len(t_queues):
-			await self.error(self.gt("You are allowed to add to {queues} queues.".format(
+			await self.error(self.gt("You are not allowed to add to {queues} queues.".format(
 				queues=join_and([f"**{q.name}**" for q in t_queues if q not in allowed])
 			)))
 

--- a/bot/queue_channel.py
+++ b/bot/queue_channel.py
@@ -545,6 +545,10 @@ class QueueChannel:
 
 		is_started = False
 		for q in t_queues:
+			if q.cfg.blacklist_role and q.cfg.blacklist_role in message.author.roles:
+				raise bot.Exc.PermissionError(self.gt("You are not allowed to add to this queue."))
+			if q.cfg.whitelist_role and q.cfg.whitelist_role not in message.author.roles:
+				raise bot.Exc.PermissionError(self.gt("You are not allowed to add to this queue."))
 			if is_started := await q.add_member(message.author):
 				break
 		if not is_started:

--- a/locales/ru.po
+++ b/locales/ru.po
@@ -49,6 +49,9 @@ msgstr "Ошибка"
 msgid "You are not allowed to add to queues."
 msgstr "Вам не разрешено добавлятся в очереди."
 
+msgid "You are not allowed to add to this queue."
+msgstr "Вам не разрешено добавлятся в эту очередь."
+
 msgid "You are already in an active match."
 msgstr "Вы уже находитесь в активном матче."
 

--- a/locales/ru.po
+++ b/locales/ru.po
@@ -46,11 +46,11 @@ msgstr "Успешно"
 msgid "Error"
 msgstr "Ошибка"
 
-msgid "You are not allowed to add to queues."
-msgstr "Вам не разрешено добавлятся в очереди."
+msgid "You are not allowed to add to queues on this channel."
+msgstr "Вам не разрешено добавлятся в очереди на этом канале."
 
-msgid "You are not allowed to add to this queue."
-msgstr "Вам не разрешено добавлятся в эту очередь."
+msgid "You are not allowed to add to {queues} queues."
+msgstr "Вам не разрешено добавлятся в очереди {queues}."
 
 msgid "You are already in an active match."
 msgstr "Вы уже находитесь в активном матче."


### PR DESCRIPTION
Dunno how to make it handle situation when members gets added to 1st target queue and then if he is not allowed in the 2nd target it raises exception and update_topic wont be called

maybe do it with try { } + final { }?